### PR TITLE
bug fix; importing os

### DIFF
--- a/scripts/monitor-wagman-service
+++ b/scripts/monitor-wagman-service
@@ -6,6 +6,7 @@ import logging
 import math
 import waggle.logging
 import json
+import os
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 


### PR DESCRIPTION
* When resetting Wagman the script fails. It is resolved by adding 'import os' in the script.