### PR TITLE
Hotfix monitor rmq crash

### DIFF
--- a/scripts/monitor-connectivity-service
+++ b/scripts/monitor-connectivity-service
@@ -9,12 +9,26 @@ import waggle.logging
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 
-beehive_reporter = waggle.logging.getLogger('monitor-connectivity')
-
+beehive_reporter = None
 
 ############################
 ##### Helper Functions #####
 ############################
+
+def report(msg, lvl="info"):
+	try:
+		if beehive_reporter == None:
+			beehive_reporter = waggle.logging.getLogger('monitor-connectivity')
+
+		if lvl=="info":
+			beehive_reporter.info(msg)
+		elif lvl=="error":
+			beehive_reporter.error(msg)
+		else:
+			beehive_reporter.debug(msg)
+	except Exception as e:
+		logging.error("Could not send message: %s" % str(e))
+
 
 # Run a command and capture it's output
 def run_command(command):
@@ -163,12 +177,12 @@ while True:
 		reset_deadman_trigger()
 		#print("Node Controller is well.")
 		logging.info("Node Controller is well.")
-		beehive_reporter.info("Node Controller is well.")
+		report("Node Controller is well.", "info")
 	else:
 		#print("Logging test failures...")
 		logging.info("The following tests failed: " + 
 					str([n for x,n in zip(results,test_names) if not x]) + "\n")
-		beehive_reporter.error("The following tests failed: " +
-					str([n for x,n in zip(results,test_names) if not x]) + "\n")
+		report("The following tests failed: " +
+					str([n for x,n in zip(results,test_names) if not x]) + "\n", "error")
 
 	time.sleep(base_sleep_time)

--- a/scripts/monitor-connectivity-service
+++ b/scripts/monitor-connectivity-service
@@ -28,6 +28,7 @@ def report_beehive(msg, lvl="info"):
 		else:
 			beehive_reporter.debug(msg)
 	except Exception as e:
+		beehive_reporter = None
 		logging.error("Could not send message: %s" % str(e))
 
 

--- a/scripts/monitor-connectivity-service
+++ b/scripts/monitor-connectivity-service
@@ -15,7 +15,8 @@ beehive_reporter = None
 ##### Helper Functions #####
 ############################
 
-def report(msg, lvl="info"):
+def report_beehive(msg, lvl="info"):
+	global beehive_reporter
 	try:
 		if beehive_reporter == None:
 			beehive_reporter = waggle.logging.getLogger('monitor-connectivity')
@@ -177,12 +178,12 @@ while True:
 		reset_deadman_trigger()
 		#print("Node Controller is well.")
 		logging.info("Node Controller is well.")
-		report("Node Controller is well.", "info")
+		report_beehive("Node Controller is well.", "info")
 	else:
 		#print("Logging test failures...")
 		logging.info("The following tests failed: " + 
 					str([n for x,n in zip(results,test_names) if not x]) + "\n")
-		report("The following tests failed: " +
+		report_beehive("The following tests failed: " +
 					str([n for x,n in zip(results,test_names) if not x]) + "\n", "error")
 
 	time.sleep(base_sleep_time)

--- a/scripts/monitor-system-service
+++ b/scripts/monitor-system-service
@@ -128,7 +128,7 @@ logging.info("waggle-system-monitor service is running...")
 
 while True:
 	current_time = time.time()
-	sleep_time = 1000000
+	sleep_time = 60
 	for entity, func, period in checklist:
 		ret = False
 		msg = ""

--- a/scripts/monitor-system-service
+++ b/scripts/monitor-system-service
@@ -9,7 +9,21 @@ import json
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 
-beehive_reporter = waggle.logging.getLogger('system-monitor')
+beehive_reporter = None
+
+def report(msg, lvl="info"):
+	try:
+		if beehive_reporter == None:
+			beehive_reporter = waggle.logging.getLogger('monitor-system')
+
+		if lvl=="info":
+			beehive_reporter.info(msg)
+		elif lvl=="error":
+			beehive_reporter.error(msg)
+		else:
+			beehive_reporter.debug(msg)
+	except Exception as e:
+		logging.error("Could not send message: %s" % str(e))
 
 def get_host_name():
 	"""
@@ -147,7 +161,7 @@ while True:
 			sleep_time = next_time
 			
 		if report:
-			beehive_reporter.info(json.dumps(check))
+			report(json.dumps(check), "info")
 
 		status[entity] = check
 

--- a/scripts/monitor-system-service
+++ b/scripts/monitor-system-service
@@ -24,6 +24,7 @@ def report_beehive(msg, lvl="info"):
 		else:
 			beehive_reporter.debug(msg)
 	except Exception as e:
+		beehive_reporter = None
 		logging.error("Could not send message: %s" % str(e))
 
 def get_host_name():

--- a/scripts/monitor-system-service
+++ b/scripts/monitor-system-service
@@ -11,7 +11,8 @@ logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(
 
 beehive_reporter = None
 
-def report(msg, lvl="info"):
+def report_beehive(msg, lvl="info"):
+	global beehive_reporter
 	try:
 		if beehive_reporter == None:
 			beehive_reporter = waggle.logging.getLogger('monitor-system')
@@ -161,7 +162,7 @@ while True:
 			sleep_time = next_time
 			
 		if report:
-			report(json.dumps(check), "info")
+			report_beehive(json.dumps(check), "info")
 
 		status[entity] = check
 

--- a/scripts/monitor-wagman-service
+++ b/scripts/monitor-wagman-service
@@ -28,6 +28,7 @@ def report_beehive(msg, lvl="info"):
 		else:
 			beehive_reporter.debug(msg)
 	except Exception as e:
+		beehive_reporter = None
 		logging.error("Could not send message: %s" % str(e))
 
 def reset_wagman():

--- a/scripts/monitor-wagman-service
+++ b/scripts/monitor-wagman-service
@@ -15,7 +15,8 @@ beehive_reporter = None
 ##### Helper Functions #####
 ############################
 
-def report(msg, lvl="info"):
+def report_beehive(msg, lvl="info"):
+	global beehive_reporter
 	try:
 		if beehive_reporter == None:
 			beehive_reporter = waggle.logging.getLogger('monitor-wagman')
@@ -162,9 +163,9 @@ class wagmanListener(object):
 
 	def report(self):
 		try:
-			report(json.dumps(self.status), "info")
+			report_beehive(json.dumps(self.status), "info")
 		except:
-			report(self.status, "info")
+			report_beehive(self.status, "info")
 		self.timer = time.time()
 
 	def run(self):

--- a/scripts/monitor-wagman-service
+++ b/scripts/monitor-wagman-service
@@ -9,11 +9,25 @@ import json
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 
-beehive_reporter = waggle.logging.getLogger('monitor-wagman')
+beehive_reporter = None
 
 ############################
 ##### Helper Functions #####
 ############################
+
+def report(msg, lvl="info"):
+	try:
+		if beehive_reporter == None:
+			beehive_reporter = waggle.logging.getLogger('monitor-wagman')
+
+		if lvl=="info":
+			beehive_reporter.info(msg)
+		elif lvl=="error":
+			beehive_reporter.error(msg)
+		else:
+			beehive_reporter.debug(msg)
+	except Exception as e:
+		logging.error("Could not send message: %s" % str(e))
 
 def reset_wagman():
 	os.system("/usr/lib/waggle/core/scripts/reset_wagman.sh")
@@ -148,9 +162,9 @@ class wagmanListener(object):
 
 	def report(self):
 		try:
-			beehive_reporter.info(json.dumps(self.status))
+			report(json.dumps(self.status), "info")
 		except:
-			beehive_reporter.info(self.status)
+			report(self.status, "info")
 		self.timer = time.time()
 
 	def run(self):
@@ -161,7 +175,7 @@ class wagmanListener(object):
 
 			if current_time - self.wagman_watchdog > self.max_wagman_silence_duration:
 				logging.info("WagMan is not well. Resetting WagMan...")
-				beehive_reporter.error("WagMan is not well. Resetting WagMan...")
+				report("WagMan is not well. Resetting WagMan...", "error")
 				reset_wagman()
 				self.wagman_watchdog = current_time
 


### PR DESCRIPTION
When the services cannot connect to RMQ the services crash. By adding _try_ will prevent the services from crashing.

However we MUST implement timeouts and attempt limits on pywaggle lib when connecting to RMQ.

This is tested on the node '299'