### PR TITLE
Branch shovel from gn

### DIFF
--- a/configure
+++ b/configure
@@ -126,6 +126,8 @@ mkdir -p /var/log/comms
 
 # install RabbitMQ configuration
 cp -r /usr/lib/waggle/nodecontroller/etc/rabbitmq /etc
+cd ${current_dir}/scripts
+./configure-rabbitmq.sh
 
 # copy systemd scripts
 cp ${current_dir}/systemd/* /etc/systemd/system

--- a/etc/rabbitmq/rabbitmq.config
+++ b/etc/rabbitmq/rabbitmq.config
@@ -19,7 +19,7 @@
    %% To listen on a specific interface, provide a tuple of {IpAddress, Port}.
    %% For example, to listen only on localhost for both IPv4 and IPv6:
    %%
-   %% {tcp_listeners, [{"127.0.0.1", 5672},
+   %% {tcp_listeners, [{"127.0.0.1", 5672}]},
    %%                  {"::1",       5672}]},
 
    %% SSL listeners are configured in the same fashion as TCP listeners,
@@ -57,11 +57,11 @@
 
    %% The default "guest" user is only permitted to access the server
    %% via a loopback interface (e.g. localhost).
-   %% {loopback_users, [<<"guest">>]},
+   {loopback_users, [<<"guest">>]}
    %%
    %% Uncomment the following line if you want to allow access to the
    %% guest user from anywhere on the network.
-   {loopback_users, []}
+   %% {loopback_users, []}
 
    %% Configuring SSL.
    %% See http://www.rabbitmq.com/ssl.html for full documentation.
@@ -353,22 +353,46 @@
        {queue, <<"data">>},
        {publish_fields, [{exchange, <<"data-pipeline-in">>}]}
       ]},
-      {logs,
-        [{sources, [{brokers, ["amqp://localhost"]},
-                    {declarations, []}]},
-         {destinations, [{broker, "amqps://node:waggle@beehive1.mcs.anl.gov:23181?cacertfile=/usr/lib/waggle/SSL/waggleca/cacert.pem&certfile=/usr/lib/waggle/SSL/node/cert.pem&keyfile=/usr/lib/waggle/SSL/node/key.pem&verify=verify_peer"},
-                         {declarations, []}]},
-         {queue, <<"logs">>},
-         {publish_fields, [{exchange, <<"logs">>}]}
-        ]},
-        {images,
-          [{sources, [{brokers, ["amqp://localhost"]},
+     {logs,
+       [{sources, [{brokers, ["amqp://localhost"]},
+                   {declarations, []}]},
+        {destinations, [{broker, "amqps://node:waggle@beehive1.mcs.anl.gov:23181?cacertfile=/usr/lib/waggle/SSL/waggleca/cacert.pem&certfile=/usr/lib/waggle/SSL/node/cert.pem&keyfile=/usr/lib/waggle/SSL/node/key.pem&verify=verify_peer"},
+                        {declarations, []}]},
+        {queue, <<"logs">>},
+        {publish_fields, [{exchange, <<"logs">>}]}
+      ]},
+     {images,
+       [{sources, [{brokers, ["amqp://localhost"]},
+                   {declarations, []}]},
+        {destinations, [{broker, "amqps://node:waggle@beehive1.mcs.anl.gov:23181?cacertfile=/usr/lib/waggle/SSL/waggleca/cacert.pem&certfile=/usr/lib/waggle/SSL/node/cert.pem&keyfile=/usr/lib/waggle/SSL/node/key.pem&verify=verify_peer"},
+                        {declarations, []}]},
+        {queue, <<"images">>},
+        {publish_fields, [{exchange, <<"images">>}]}
+      ]},
+     {data_gn,
+       [{sources, [{brokers, ["amqp://%GUESTNODE_IP%"]},
+                 {declarations, []}]},
+      {destinations, [{broker, "amqps://node:waggle@beehive1.mcs.anl.gov:23181?cacertfile=/usr/lib/waggle/SSL/waggleca/cacert.pem&certfile=/usr/lib/waggle/SSL/node/cert.pem&keyfile=/usr/lib/waggle/SSL/node/key.pem&verify=verify_peer"},
                       {declarations, []}]},
-           {destinations, [{broker, "amqps://node:waggle@beehive1.mcs.anl.gov:23181?cacertfile=/usr/lib/waggle/SSL/waggleca/cacert.pem&certfile=/usr/lib/waggle/SSL/node/cert.pem&keyfile=/usr/lib/waggle/SSL/node/key.pem&verify=verify_peer"},
-                           {declarations, []}]},
-           {queue, <<"images">>},
-           {publish_fields, [{exchange, <<"images">>}]}
-          ]}
+      {queue, <<"data">>},
+      {publish_fields, [{exchange, <<"data-pipeline-in">>}]}
+     ]},
+     {logs_gn,
+       [{sources, [{brokers, ["amqp://%GUESTNODE_IP%"]},
+                 {declarations, []}]},
+      {destinations, [{broker, "amqps://node:waggle@beehive1.mcs.anl.gov:23181?cacertfile=/usr/lib/waggle/SSL/waggleca/cacert.pem&certfile=/usr/lib/waggle/SSL/node/cert.pem&keyfile=/usr/lib/waggle/SSL/node/key.pem&verify=verify_peer"},
+                      {declarations, []}]},
+      {queue, <<"logs">>},
+      {publish_fields, [{exchange, <<"logs">>}]}
+     ]},
+     {images_gn,
+       [{sources, [{brokers, ["amqp://%GUESTNODE_IP%"]},
+                 {declarations, []}]},
+      {destinations, [{broker, "amqps://node:waggle@beehive1.mcs.anl.gov:23181?cacertfile=/usr/lib/waggle/SSL/waggleca/cacert.pem&certfile=/usr/lib/waggle/SSL/node/cert.pem&keyfile=/usr/lib/waggle/SSL/node/key.pem&verify=verify_peer"},
+                      {declarations, []}]},
+      {queue, <<"images">>},
+      {publish_fields, [{exchange, <<"images">>}]}
+     ]}
     ]},
    {defaults, [{prefetch_count,     0},
                {ack_mode,           on_confirm},

--- a/scripts/configure-rabbitmq.sh
+++ b/scripts/configure-rabbitmq.sh
@@ -2,3 +2,8 @@
 
 . /usr/lib/waggle/core/scripts/detect_mac_address.sh
 sed -i -e "s/%NODE_ID%/$NODE_ID/" /etc/rabbitmq/rabbitmq.config
+
+# Shovels for guest node
+GUESTNODE_IP=$(cat /etc/hosts | grep -m 1 extensionnode | awk '{print $1}')
+sed -i -e "s/%GUESTNODE_IP%/$GUESTNODE_IP/" /etc/rabbitmq/rabbitmq.config
+

--- a/scripts/configure-system.sh
+++ b/scripts/configure-system.sh
@@ -38,7 +38,4 @@ echo >> /home/waggle/.ssh/authorized_keys
 
 # Setup RabbitMQ config files.
 cp -r /usr/lib/waggle/nodecontroller/etc/rabbitmq /etc
-
-# Just in case for now...ideally this would be in /etc/envinronment already.
-WAGGLE_ID=$(ip link | awk '/ether 00:1e:06/ { print $2 }' | sed 's/://g')
-sed -i -e "s/%WAGGLE_ID%/$WAGGLE_ID/" /etc/rabbitmq/rabbitmq.config
+/usr/lib/waggle/nodecontroller/scripts/configure-rabbitmq.sh


### PR DESCRIPTION
Configure RMQ shovels for guest node. The IP address is set through configure-rabbitmq.sh

Messages from guestnode will bypass nodecontroller (will not be stored in the nodecontroller).